### PR TITLE
update engines.node semver range in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run-script clean && npm run-script compile && npm run-script browser"
   },
   "engines": {
-    "node": ">= 0.5.0 < 0.7.0"
+    "node": ">= 0.5.0 - 0.10.x"
   },
   "dependencies": {
     "html-minifier": ">=0.4.5",


### PR DESCRIPTION
Per https://github.com/cstivers78/bliss/issues/6

Since none of the code changed, I left the module version number the same. do `npm publish -f` to republish the current version (1.0.1) with the new package.json
